### PR TITLE
fix:  prevent currency formatting error when "between" range input is cleared by user

### DIFF
--- a/src/Filters/ValueRangeFilter.php
+++ b/src/Filters/ValueRangeFilter.php
@@ -220,7 +220,7 @@ class ValueRangeFilter extends Filter
 
     protected function getFormattedValue($value)
     {
-        if ($this->isCurrency() && $value !== null) {
+        if ($this->isCurrency() && $value !== null && !empty($value)) {
             return $this->isCurrency ? Number::currency($value, in: $this->currencyCode, locale: $this->locale) : $value;
         }
 


### PR DESCRIPTION
When the "between" range option is selected and a user deletes either the "from" or "to" value, a string (empty value) is passed to Number::currency(), which expects a float or int. This caused a type error in PHP.

`Illuminate\Support\Number::currency(): Argument #1 ($number) must be of type int|float, string given`