### PR TITLE
Add Dutch translations for value range filter options

### DIFF
--- a/resources/lang/nl/filament-value-range-filter.php
+++ b/resources/lang/nl/filament-value-range-filter.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    'range.placeholder' => 'Selecteer conditie',
+    'range.options.equal' => 'is gelijk aan',
+    'range.options.not_equal' => 'is niet gelijk aan',
+    'range.options.between' => 'ligt tussen',
+    'range.options.greater_than' => 'is groter dan',
+    'range.options.greater_than_equal' => 'is groter dan of gelijk aan',
+    'range.options.less_than' => 'is kleiner dan',
+    'range.options.less_than_equal' => 'is kleiner dan of gelijk aan',
+    'range.indicator.equal' => ':label is gelijk aan :value',
+    'range.indicator.not_equal' => ':label is niet gelijk aan :value',
+    'range.indicator.between' => ':label ligt tussen :fromValue en :toValue',
+    'range.indicator.greater_than' => ':label is groter dan :value',
+    'range.indicator.greater_than_equal' => ':label is groter dan of gelijk aan :value',
+    'range.indicator.less_than' => ':label is kleiner dan :value',
+    'range.indicator.less_than_equal' => ':label is kleiner dan of gelijk aan :value',
+
+];


### PR DESCRIPTION
This pull request adds Dutch language translations for the value range filter in the `resources/lang/nl/filament-value-range-filter.php` file. The translations include placeholders, options, and indicators for various conditions related to range filtering.

Language translation additions:

* [`resources/lang/nl/filament-value-range-filter.php`](diffhunk://#diff-28f369d8f530afe9585e0ff78683f4d5379caca71dbc8eb1826aa7565a168371R1-R21): Added Dutch translations for range filter conditions such as "is gelijk aan" (equal), "is niet gelijk aan" (not equal), "ligt tussen" (between), and others. These translations cover both user-selectable options and indicators for displaying selected conditions.