### PR TITLE
[Filament 4.x] Add Dutch translations for value range filter options

### DIFF
--- a/resources/lang/nl/filament-value-range-filter.php
+++ b/resources/lang/nl/filament-value-range-filter.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    'range.placeholder' => 'Selecteer conditie',
+    'range.options.equal' => 'is gelijk aan',
+    'range.options.not_equal' => 'is niet gelijk aan',
+    'range.options.between' => 'ligt tussen',
+    'range.options.greater_than' => 'is groter dan',
+    'range.options.greater_than_equal' => 'is groter dan of gelijk aan',
+    'range.options.less_than' => 'is kleiner dan',
+    'range.options.less_than_equal' => 'is kleiner dan of gelijk aan',
+    'range.indicator.equal' => ':label is gelijk aan :value',
+    'range.indicator.not_equal' => ':label is niet gelijk aan :value',
+    'range.indicator.between' => ':label ligt tussen :fromValue en :toValue',
+    'range.indicator.greater_than' => ':label is groter dan :value',
+    'range.indicator.greater_than_equal' => ':label is groter dan of gelijk aan :value',
+    'range.indicator.less_than' => ':label is kleiner dan :value',
+    'range.indicator.less_than_equal' => ':label is kleiner dan of gelijk aan :value',
+
+];


### PR DESCRIPTION
This pull request adds a new Dutch language translation file for value range filter options and indicators. The file provides localized strings for various filter conditions and their descriptions.

Localization:

* Added `resources/lang/nl/filament-value-range-filter.php` with Dutch translations for range filter options such as "equal", "not equal", "between", "greater than", "less than", and their respective indicator phrases.