### PR TITLE
Update PHP test matrix to 8.4/8.5, drop 8.2

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -15,6 +15,7 @@ jobs:
         uses: aglipanci/laravel-pint-action@2.6
         with:
           preset: laravel
+          php_version: 8.5
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,4 +53,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --no-coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.2]
+        php: [8.5, 8.4]
         laravel: [12.*, 11.*]
         stability: [prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "source": "https://github.com/TappNetwork/filament-value-range-filter"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/filament": "^5.0|^4.0"
     },
     "require-dev": {
@@ -35,9 +35,9 @@
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9|^3.0",
         "orchestra/testbench": "^8.20|^9.0|^10.0",
-        "pestphp/pest": "^2.0|^3.0",
-        "pestphp/pest-plugin-arch": "^2.0|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.0",
+        "pestphp/pest": "^2.0|^3.0|^4.0",
+        "pestphp/pest-plugin-arch": "^2.0|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1|^2.0",
         "phpstan/phpstan-phpunit": "^1.3|^2.0"


### PR DESCRIPTION
## Summary

- Updates the test matrix in `run-tests.yml` to PHP 8.4 and 8.5, removing 8.2
- Pins the Pint linting workflow (`pint.yml`) to PHP 8.5 via `php_version: 8.5`

## Test plan

- [ ] Verify CI runs tests against PHP 8.4 and 8.5
- [ ] Verify Pint workflow runs on PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)